### PR TITLE
fix: naive approach to AccessTokenExchange

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -177,8 +177,12 @@ impl Client {
         AuthorizationUrlBuilder::new(self, redirect_uri)
     }
 
-    pub fn access_token_exchange<'a>(&'a self, code: &'a str) -> AccessTokenExchangeBuilder<'a> {
-        AccessTokenExchangeBuilder::new(self, code)
+    pub fn access_token_exchange<'a>(
+        &'a self,
+        code: &'a str,
+        redirect_uri: &'a str,
+    ) -> Result<AccessTokenExchangeBuilder<'a>, RedirectUriInvalidError<'a>> {
+        AccessTokenExchangeBuilder::new(self, code, redirect_uri)
     }
 
     pub fn refresh_token_exchange<'a>(


### PR DESCRIPTION
The way the `AccessTokenExchange` was implemented had it set the `redirect_url` as the first of the possible redirect url list. This possibly never did, but definitely no longer works. The `redirect_url` needs to match that that the token was retrieved with. This pr adds the functionality and requirement to specify the redirect url used.